### PR TITLE
CRUDPlace 에 MemoryCRUDPlace 클래스 추가

### DIFF
--- a/.github/workflows/feature-branch-workflow.yml
+++ b/.github/workflows/feature-branch-workflow.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up Python 3.11
         uses: actions/setup-python@v2
         with:
-          python-version: 3.11
+          python-version: 3.11.5
 
       - name: Set PYTHONPATH
         run: echo "PYTHONPATH=$(pwd)" >> $GITHUB_ENV
@@ -57,8 +57,7 @@ jobs:
 
       - name: Run tests with coverage
         run: |
-          pipenv run pytest -s -v -m "not isolated" --cov --cov-report=xml:./coverage.xml
-          pipenv run pytest -s -v -n auto -m "isolated" --cov --cov-append --cov-report=xml:./coverage.xml
+          pipenv run pytest -s -v --cov --cov-report=xml:./coverage.xml
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Pull base image
-FROM python:3.11
+FROM python:3.11.5
 
 # Set environment varibles
 ENV PYTHONDONTWRITEBYTECODE 1
@@ -16,6 +16,7 @@ COPY ./main.py .
 COPY ./alembic /Meet-Up-Spot/alembic
 COPY ./alembic.ini .
 COPY ./app ./app
+COPY ./prestart.sh .
 
 EXPOSE 8000
 ENV PYTHONPATH=/Meet-Up-Spot

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test_in_actions:
 	-PIPENV_DOTENV_LOCATION=test.env pipenv run pytest -s -v -n auto -m "isolated" --cov --cov-append --cov-report=xml:./coverage.xml
 	docker-compose -f ./testing.yml down 
 
-test:
+test_mark:
 	docker-compose -f ./testing.yml up test-db -d
 	PIPENV_DOTENV_LOCATION=test.env pipenv run alembic upgrade head
 	PIPENV_DOTENV_LOCATION=test.env pipenv run python app/initial_data.py
@@ -22,5 +22,24 @@ test:
 	-PIPENV_DOTENV_LOCATION=test.env pipenv run pytest -s -v -n auto -m "isolated" --cov --cov-append --cov-report=term
 	docker-compose -f ./testing.yml down 
 
+test_one:
+	docker-compose -f ./testing.yml up test-db -d
+	-PIPENV_DOTENV_LOCATION=test.env pipenv run pytest -s -v ${test-path}
+	docker-compose -f ./testing.yml down 
+
 run_pgadmin:
 	docker-compose -f ./testing.yml up -d pgamdin
+
+
+first_user:
+	docker-compose run --rm web python app/initial_data.py
+
+meet-build:
+	docker-compose build
+meet-up:
+	docker-compose up 
+meet-down:
+	docker-compose down
+
+meet-initial-data:
+	docker-compose exec web python app/initial_data.py

--- a/app/schemas/place.py
+++ b/app/schemas/place.py
@@ -10,6 +10,7 @@ class PlaceBase(BaseModel):
     address: str
     user_ratings_total: int | None = None
     rating: float | None = None
+    place_types: List[str] | None = None
 
     def __eq__(self, other):
         if isinstance(other, PlaceBase):

--- a/app/services/routes_matrix_services.py
+++ b/app/services/routes_matrix_services.py
@@ -3,6 +3,8 @@ from collections import defaultdict, namedtuple
 from typing import List
 
 from app import crud
+from app.core.config import get_app_settings
+from app.crud.crud_place import CRUDPlaceFactory
 from app.models.place import Place
 from app.schemas.google_maps_api import DistanceInfo
 from app.schemas.place import PlaceUpdate
@@ -12,6 +14,8 @@ DestinationSummary = namedtuple("DestinationSummary", ("destination_id, total_va
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+app_settings = get_app_settings()
 
 
 class RoutesMatrix:
@@ -26,6 +30,7 @@ class RoutesMatrix:
         :param distance_matrix: The distance matrix results.
         :param candidates: The list of candidates to update.
         """
+        place_crud = CRUDPlaceFactory.get_instance(app_settings.APP_ENV)
         candidates_dict = {candidate.place_id: candidate for candidate in candidates}
         for matrix in self.distance_matrix:
             candidate = candidates_dict.get(matrix.destination_id)
@@ -36,7 +41,7 @@ class RoutesMatrix:
                 updated_data = PlaceUpdate(
                     place_id=candidate.place_id, address=matrix.destination
                 )
-                crud.place.update(db, db_obj=candidate, obj_in=updated_data)
+                place_crud.update(db, db_obj=candidate, obj_in=updated_data)
 
     @property
     def group_by_destination(self) -> dict:

--- a/app/tests/crud/test_place.py
+++ b/app/tests/crud/test_place.py
@@ -1,49 +1,64 @@
 from sqlalchemy.orm import Session
 
 from app import crud
+from app.core.settings.app import AppSettings
+from app.crud.crud_place import CRUDPlaceFactory
 from app.models.place import PlaceType
+from app.schemas.place import PlaceUpdate
 from app.tests.utils.places import create_random_place
 
 
-def test_create_place(db: Session):
-    place = create_random_place(db, name="Test Place")
+def test_create_place(db: Session, settings: AppSettings):
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+
+    place = create_random_place(db, crud_place=crud_place, name="Test Place")
 
     assert place.name == "Test Place"
 
 
-def test_get_by_place_id(db: Session):
-    place = create_random_place(db)
-    stored_place = crud.place.get_by_place_id(db, id=place.place_id)
+def test_get_by_place_id(db: Session, settings: AppSettings):
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+
+    place = create_random_place(db, crud_place=crud_place)
+    stored_place = crud_place.get_by_place_id(db, id=place.place_id)
+
     assert stored_place
     assert stored_place.place_id == place.place_id
 
 
-def test_update_place_name(db: Session):
-    place = create_random_place(db, name="Test Place")
+def test_update_place_name(db: Session, settings: AppSettings):
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+
+    place = create_random_place(db, crud_place=crud_place, name="Test Place")
     assert place.name == "Test Place"
     new_name = "New Name"
-    place_update = {"name": new_name}
-    crud.place.update(db, db_obj=place, obj_in=place_update)
-    updated_place = crud.place.get_by_place_id(db, id=place.place_id)
+
+    place_update = PlaceUpdate(name=new_name, place_id=place.place_id, address="Test")
+    crud_place.update(db, db_obj=place, obj_in=place_update)
+    updated_place = crud_place.get_by_place_id(db, id=place.place_id)
     assert updated_place.name == new_name
 
 
-def test_update_place_types(db: Session):
-    place = create_random_place(db, types=["cafe"])
+def test_update_place_types(db: Session, settings: AppSettings):
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+    place = create_random_place(db, crud_place=crud_place, types=["cafe"])
 
     assert place.place_types[0].type_name == "cafe"
 
     new_types = ["restaurant"]
-    place_update = {"place_types": new_types}
-    crud.place.update(db, db_obj=place, obj_in=place_update)
-    updated_place = crud.place.get_by_place_id(db, id=place.place_id)
+    place_update = PlaceUpdate(
+        name=place.name, place_id=place.place_id, address="Test", place_types=new_types
+    )
+    crud_place.update(db, db_obj=place, obj_in=place_update)
+    updated_place = crud_place.get_by_place_id(db, id=place.place_id)
     assert len(updated_place.place_types) == 1
     assert updated_place.place_types[0].type_name == new_types[0]
 
 
-def test_convert_strings_to_place_types(db: Session):
+def test_convert_strings_to_place_types(db: Session, settings: AppSettings):
     place_types = ["cafe", "restaurant"]
-    types = crud.place.convert_strings_to_place_types(db, place_types)
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+    types = crud_place.convert_strings_to_place_types(db, place_types)
     assert len(types) == 2
     assert type(types[0]) == PlaceType
     assert types[0].type_name == place_types[0]

--- a/app/tests/crud/test_user.py
+++ b/app/tests/crud/test_user.py
@@ -3,6 +3,8 @@ from sqlalchemy.orm import Session
 
 from app import crud
 from app.core.security import verify_password
+from app.core.settings.app import AppSettings
+from app.crud.crud_place import CRUDPlaceFactory
 from app.schemas.user import UserCreate, UserUpdate
 from app.tests.utils.places import create_random_place
 from app.tests.utils.utils import random_email, random_lower_string
@@ -95,12 +97,14 @@ def test_update_user(db: Session) -> None:
     assert verify_password(new_password, user_2.hashed_password)
 
 
-def test_mark_unmark_interest(db: Session) -> None:
+def test_mark_unmark_interest(db: Session, settings: AppSettings) -> None:
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
     password = random_lower_string()
     email = random_email()
     user_in = UserCreate(email=email, password=password, is_superuser=True)
     user = crud.user.create(db, obj_in=user_in)
-    place = create_random_place(db)
+
+    place = create_random_place(db, crud_place)
 
     user = crud.user.mark_interest(db, user=user, place=place)
     assert user
@@ -120,12 +124,14 @@ def test_mark_unmark_interest(db: Session) -> None:
     db.commit()
 
 
-def test_has_interest(db: Session) -> None:
+def test_has_interest(db: Session, settings: AppSettings) -> None:
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV, False)
+
     password = random_lower_string()
     email = random_email()
     user_in = UserCreate(email=email, password=password, is_superuser=True)
     user = crud.user.create(db, obj_in=user_in)
-    place = create_random_place(db)
+    place = create_random_place(db, crud_place)
 
     user = crud.user.mark_interest(db, user=user, place=place)
     assert user

--- a/app/tests/services/test_routes_matrix.py
+++ b/app/tests/services/test_routes_matrix.py
@@ -1,56 +1,69 @@
+from unittest.mock import patch
+
 import pytest
 
+from app.core.settings.app import AppSettings
+from app.crud.crud_place import CRUDPlaceFactory
 from app.schemas.google_maps_api import DistanceInfo
 from app.services.constants import AGGREGATED_ATTR
 from app.services.routes_matrix_services import DestinationSummary, RoutesMatrix
 from app.tests.utils.places import create_random_place, distance_info_list
 
 
-@pytest.mark.isolated
-def test_update_candidate_addresses(db):
-    place_has_no_address = [
-        create_random_place(
-            db,
-            place_id="1",
-            name="판교역",
-            address="fake1",
-        ),
-        create_random_place(
-            db,
-            place_id="2",
-            name="서울역",
-            address="fake2",
-        ),
-    ]
+def test_update_candidate_addresses(db, settings: AppSettings):
+    crud_place = CRUDPlaceFactory.get_instance(settings.APP_ENV)
+    with patch("app.crud.crud_place.CRUDPlaceFactory.get_instance") as mock_instance:
+        mock_instance.return_value = crud_place
+        place_has_no_address = [
+            create_random_place(
+                db,
+                crud_place=crud_place,
+                place_id="1",
+                name="판교역",
+                address="fake1",
+            ),
+            create_random_place(
+                db,
+                crud_place=crud_place,
+                place_id="2",
+                name="서울역",
+                address="fake2",
+            ),
+        ]
 
-    destination_with_perfect_address = [
-        DistanceInfo(
-            origin="대한민국 경기도 성남시 분당구 성남대로 지하 601 서현",
-            destination_id="1",
-            destination="perfect1",
-            distance_text="2.2 km",
-            distance_value=2186,
-            duration_text="22분",
-            duration_value=1299,
-        ),
-        DistanceInfo(
-            origin="대한민국 경기도 성남시 분당구 성남대로 지하 601 서현",
-            destination_id="2",
-            destination="perfect2",
-            distance_text="2.2 km",
-            distance_value=2186,
-            duration_text="22분",
-            duration_value=1299,
-        ),
-    ]
-    assert place_has_no_address[0].address == "fake1"
-    assert place_has_no_address[1].address == "fake2"
+        destination_with_perfect_address = [
+            DistanceInfo(
+                origin="대한민국 경기도 성남시 분당구 성남대로 지하 601 서현",
+                destination_id="1",
+                destination="perfect1",
+                distance_text="2.2 km",
+                distance_value=2186,
+                duration_text="22분",
+                duration_value=1299,
+            ),
+            DistanceInfo(
+                origin="대한민국 경기도 성남시 분당구 성남대로 지하 601 서현",
+                destination_id="2",
+                destination="perfect2",
+                distance_text="2.2 km",
+                distance_value=2186,
+                duration_text="22분",
+                duration_value=1299,
+            ),
+        ]
+        assert place_has_no_address[0].address == "fake1"
+        assert place_has_no_address[1].address == "fake2"
+        routes_matrix = RoutesMatrix(destination_with_perfect_address)
+        routes_matrix.update_candidate_addresses(db, place_has_no_address)
 
-    routes_matrix = RoutesMatrix(destination_with_perfect_address)
-    routes_matrix.update_candidate_addresses(db, place_has_no_address)
-
-    assert place_has_no_address[0].address == "perfect1"
-    assert place_has_no_address[1].address == "perfect2"
+        assert (
+            crud_place.get_by_place_id(id=place_has_no_address[0].place_id).address
+            == "perfect1"
+        )
+        assert (
+            crud_place.get_by_place_id(id=place_has_no_address[1].place_id).address
+            == "perfect2"
+        )
 
 
 def test_sort_destinations_by_aggregated_attr():

--- a/app/tests/utils/places.py
+++ b/app/tests/utils/places.py
@@ -95,7 +95,8 @@ def create_random_location(db: Session):
 
 
 def create_random_place(
-    db: Session,
+    db: Session = None,
+    crud_place=None,
     place_id: str = None,
     name: str = None,
     address: str = None,
@@ -119,7 +120,7 @@ def create_random_place(
         place_types=place_types,
     )
 
-    return crud.place.create(db, obj_in=place_in)
+    return crud_place.create(db, obj_in=place_in)
 
 
 distance_info_list = [

--- a/test.env
+++ b/test.env
@@ -1,0 +1,21 @@
+DATABASE_URL = "postgresql+psycopg2://postgres:DO_NOT_USE_THIS_PASSWORD_IN_PRODUCTION@127.0.0.1:5432/test_db"
+APP_ENV = 'test'
+
+POSTGRES_HOST = "test-db"
+POSTGRES_TEST_USER = "postgres"
+POSTGRES_TEST_PASSWORD = "DO_NOT_USE_THIS_PASSWORD_IN_PRODUCTION"
+POSTGRES_TEST_DB = "test_db"
+BACKEND_CORS_ORIGINS="[\"http://localhost\" , \"http://localhost:8000\",\"http://localhost:3000\" ]"
+
+SMTP_TLS="true"
+SMTP_PORT=587
+SMTP_HOST = "smtp.gmail.com"
+EMAILS_FROM_EMAIL="info@Meet-up-spot.com"
+EMAILS_FROM_NAME ="Meet-up-spot"
+
+
+GOOGLE_MAPS_NEARBY_SEARCH_URL = "https://maps.googleapis.com/maps/api/place/nearbysearch/json"
+FIRST_SUPERUSER = "admin@Meet-up-spot.com"
+FIRST_SUPERUSER_PASSWORD = "admin"
+EMAIL_TEST_USER = "test@example.com"
+EMAIL_TEST_USER_PASSWORD = "test"

--- a/testing.yml
+++ b/testing.yml
@@ -18,6 +18,8 @@ services:
       - POSTGRES_PASSWORD=DO_NOT_USE_THIS_PASSWORD_IN_PRODUCTION
       - POSTGRES_DB=test_db
       - APP_ENV=test
+    env_file:
+      - test.env
 
   test-web:
     build: .
@@ -33,6 +35,8 @@ services:
       - SMTP_USER=${SMTP_USER}
       - SMTP_PASSWORD=${SMTP_PASSWORD}
       - APP_ENV=test
+    env_file:
+      - test.env
 
   test-pgadmin:
     container_name: pgadmin
@@ -44,6 +48,8 @@ services:
       - "5040:80"
     depends_on:
       - test-db
+    env_file:
+      - test.env
 
 volumes:
   test-db-data:


### PR DESCRIPTION
## 개요
이 PR에서는 CRUDPlace에 MemoryCRUDPlace와 CRUDPlaceFactory를 도입함. 이를 통해, 특히 테스트 환경에서 메모리 기반 CRUD 연산을 수행할 수 있게 되었음

## 주요 변경 사항
1. **MemoryCRUDPlace 추가**: 
   - 메모리에서 CRUD 연산을 수행할 수 있는 클래스
   - 이는 테스트 환경에서 DB 연결 없이 CRUD 연산을 테스트하고자 할 때 사용

2. **CRUDPlaceFactory 추가**: 
   - CRUDPlace와 MemoryCRUDPlace 사이에서 선택하여 인스턴스를 생성할 수 있게 도와주는 팩토리 클래스.
   - 현재 APP 환경 설정(AppEnvTypes)과 메모리 사용 여부(use_memory)에 따라 적절한 인스턴스를 반환함.

3. **기존 코드와 테스트 케이스 수정**:
   - place crud 관련 기존의 코드와 테스트 케이스 일부 수정.

## 기타
다른 모델도 원래 같이 추가하려 했지만, 추후에 진행하는게 나을거 같아서 일단은 보류. 
또한 세션을 레포지토리에 묶으려고 했으나 코드가 너무 많이 수정해야해서. 우선순위를 생각했을때 
추천 작업 마무리가 급해 보여서 일단 그냥 진행할 예정
  