### PR TITLE
배포를 위한 Actions 워크플로우 추가

### DIFF
--- a/.github/workflows/deploy-to-gke-production.yaml
+++ b/.github/workflows/deploy-to-gke-production.yaml
@@ -1,0 +1,55 @@
+name: Build and deploy the main branch
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+
+env:
+  DOCKER_IMAGE: gcr.io/pioneering-rex-402212/meet-up-spot:production-${{ github.sha }}
+  GKE_PROJECT: pioneering-rex-402212
+  GKE_ZONE: us-central1-a
+  GKE_CLUSTER: cluster-1
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - id: "auth"
+        uses: "google-github-actions/auth@v1"
+        with:
+          credentials_json: "${{ secrets.GKE_SA_KEY }}"
+
+      - name: "Set up Cloud SDK"
+        uses: "google-github-actions/setup-gcloud@v1"
+
+      - name: Configure Docker
+        run: |
+          gcloud --quiet auth configure-docker
+
+      - name: Install Kustomize
+        run: |
+          curl -s "https://raw.githubusercontent.com/kubernetes-sigs/kustomize/master/hack/install_kustomize.sh" | bash
+          sudo mv kustomize /usr/local/bin/
+
+      - uses: simenandre/setup-gke-gcloud-auth-plugin@v1
+
+      - uses: google-github-actions/get-gke-credentials@v1
+        with:
+          cluster_name: ${{ env.GKE_CLUSTER }}
+          location: ${{ env.GKE_ZONE }}
+
+      - name: Set image tag
+        run: |
+          cd docker/production
+          kustomize edit set image gcr.io/pioneering-rex-402212/meet-up-spot=${{ env.DOCKER_IMAGE }}
+
+      - name: Check kubectl location
+        run: which kubectl
+
+      - name: Deploy to GKE
+        run: |
+          kustomize build docker/production | kubectl apply -f -

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,18 +8,34 @@ ENV APP_ENV "proudction"
 
 WORKDIR /Meet-Up-Spot
 
-# Install dependencies
+# Install python dependencies
 RUN pip install pipenv
 COPY ./Pipfile ./Pipfile.lock /Meet-Up-Spot/
 RUN pipenv install --system --dev
+
+# Install Node.js and npm
+RUN apt-get update && apt-get install -y nodejs npm
+# Install MJML
+RUN npm install -g mjml
+
+# Create directory for MJML build files
+RUN mkdir -p /Meet-Up-Spot/app/email-templates/build/
+
 
 COPY ./main.py /Meet-Up-Spot/main.py
 COPY ./alembic /Meet-Up-Spot/alembic
 COPY ./alembic.ini /Meet-Up-Spot/alembic.ini
 COPY ./app /Meet-Up-Spot/app
-COPY ./prestart.sh /Meet-Up-Spot/prestart.sh
+COPY ./test_prestart.sh /Meet-Up-Spot/test_prestart.sh
 COPY docker/entrypoint.sh  /Meet-Up-Spot/entrypoint.sh 
 RUN chmod +x /Meet-Up-Spot/entrypoint.sh
+
+
+RUN for file in /Meet-Up-Spot/app/email-templates/src/*.mjml; do \
+    name=$(basename $file .mjml); \
+    mjml $file -o /Meet-Up-Spot/app/email-templates/build/${name}.html; \
+    done
+
 
 ENTRYPOINT ["./entrypoint.sh"]
 

--- a/app/db/init_db.py
+++ b/app/db/init_db.py
@@ -1,12 +1,10 @@
-from fastapi import Depends
 from sqlalchemy.orm import Session
 
 from app import crud, schemas
 from app.core.config import get_app_settings
-from app.core.settings.app import AppSettings
-from app.db import base  # noqa: F401
 
 settings = get_app_settings()
+
 
 def init_db(
     db: Session,

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -6,7 +6,7 @@ alembic upgrade head
 
 
 if [ "$APP_ENV" = "production" ]; then
-    uvicorn main:app --host 0.0.0.0 --port 8000 workers 3
+    uvicorn main:app --host 0.0.0.0 --port 8000 --workers 3
 else
    uvicorn main:app --host 0.0.0.0 --port 8000 --reload
 fi

--- a/docker/production/kustomization.yaml
+++ b/docker/production/kustomization.yaml
@@ -1,0 +1,9 @@
+# docker/production/kustomization.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - web.yaml
+  - pgadmin.yaml
+  - redis.yaml
+  - redis-data-persistentvolumeclaim.yaml

--- a/docker/production/web.yaml
+++ b/docker/production/web.yaml
@@ -60,9 +60,9 @@ spec:
                   name: meet-up-spot-config
             - name: FIRST_SUPERUSER_PASSWORD
               valueFrom:
-                configMapKeyRef:
+                secretKeyRef:
                   key: FIRST_SUPERUSER_PASSWORD
-                  name: meet-up-spot-config
+                  name: meet-up-spot-secret
             - name: GOOGLE_MAPS_API_KEY
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
이 PR은 애플리케이션을 빌드, 발행, 배포하기 위한 GitHub Actions 워크플로우를 도입합니다. 이 워크플로우는  'main' 브랜치에 푸시될 때 트리거됩니다. 

