### PR TITLE
배포 Actions 파일 수정

### DIFF
--- a/.github/workflows/deploy-to-gke-production.yaml
+++ b/.github/workflows/deploy-to-gke-production.yaml
@@ -14,7 +14,7 @@ jobs:
   build_and_tag:
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.tag_version.outputs.version }}
+      version: ${{ steps.tag_version.outputs.new_tag }}
     steps:
       - name: Bump version and push tag
         id: tag_version

--- a/docker/production/web.yaml
+++ b/docker/production/web.yaml
@@ -26,6 +26,11 @@ spec:
       labels:
         app: web
     spec:
+      strategy:
+        type: RollingUpdate
+        rollingUpdate:
+          maxSurge: 0
+          maxUnavailable: 1
       serviceAccountName: dumpling
       containers:
         - name: web


### PR DESCRIPTION
# 변경사항
- 배포를 위한 태그 부분 수정
- GKE 노드 할당량 넘쳐서 deployment 전략 수정
  -  maxSurge를 1로 하고 maxUnavailable 을 0으로 해서 일단 기존꺼 중단 시키고 새로운 pod 띄움. 
  - 이거 아니면 restart 로 바꿔도 됨
  - 아니면 노드 추가해야함
